### PR TITLE
Fix image reference in README

### DIFF
--- a/labs/Introduction-To-Eagle/Creating-Surface-Mount-Parts.md
+++ b/labs/Introduction-To-Eagle/Creating-Surface-Mount-Parts.md
@@ -10,7 +10,7 @@ The course style guidelines for libraries are in the "Guidelines for Building...
 
 Create a new schematic and board files named `smd.sch` and `smd.brd` and load the DRU file for error checking. Remember for creating a new design `File->New Electronics Design` and save the design as `smd`. Then in the design tab `Create->New Schematic` and save the schematic as `smd`. Then in the design tab `Create->New Board` or in the schematic tab `Switch to PCB document`. Add the same components, with the exception of the through-hole push button. You can add the components into the schematic manually. However, if you are a desperate person as me, instead of adding the components again manually you can copy the entire schematic by going to the throughhole schematic tab, then clicking `Group Select` and selecting all components including the FRAME, then Ctr+C, then switch to the smd.sch tab and Ctr+V. Finally, delete the through hole push button. The tabs and smd schematic should look as follows:
 
-![](images/smdtutpoorial1.jpg)
+![](images/smdtutorial1.png)
 
 This time instead of adding the throughhole (TH) push button component from a library we will create our own push button component inside a library which will be surface mount (SMD) instead. We will create part number [1301.9315](https://www.digikey.com/en/products/detail/schurter-inc/1301-9315/2643952) which has the following [datasheet](https://www.schurter.com/en/datasheet/typ_6x6_mm_tact_switches.pdf). It's the one that looks like this:
 


### PR DESCRIPTION
This PR corrects a typo in an image path that causes it not to display in the README. 